### PR TITLE
Fix unbound variable in snmp_c2s_SUITE.erl

### DIFF
--- a/tests/snmp_c2s_SUITE.erl
+++ b/tests/snmp_c2s_SUITE.erl
@@ -260,7 +260,7 @@ error_presence(Config) ->
 
         end).
 
-error_iq(_Config) ->
+error_iq(Config) ->
     {value, Errors} = get_counter_value(xmppErrorIq),
 
     Alice = escalus_users:get_user_by_name(alice),


### PR DESCRIPTION
This problem was introduced in commit
eaf1621b16c442edbfd0d2b179cbaedde43f9e24 .
