### PR TITLE
Add termination hint in bosh timeout test, start metrics helper w/checks

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,11 @@
 {erl_opts, [debug_info,
             {i, ["include"]}]}.
 
-{require_otp_vsn, "R1[456]"}.
+{require_otp_vsn, "R?1[4567]"}.
 
 {deps, [
-    {escalus, "2\.4\..*", {git, "git://github.com/esl/escalus.git", {tag, "2.4.0"}}},
+    {escalus, "2\.4\..*", {git, "git://github.com/esl/escalus.git", {tag, "2.4.1"}}},
     {exml, "2\.1\..*", {git, "git://github.com/esl/exml.git", {tag, "2.1.3"}}},
+    {lhttpc, ".*", {git, "git://github.com/esl/lhttpc.git", "3c7fdee"}},
     {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}}
 ]}.

--- a/tests/metrics_helper.erl
+++ b/tests/metrics_helper.erl
@@ -1,5 +1,10 @@
 -module(metrics_helper).
 
+%%
+%%  @TODO Please consider refactoring this
+%%  module to use esl/fusco as the http client.
+%%
+
 -include_lib("common_test/include/ct.hrl").
 
 -compile(export_all).
@@ -74,13 +79,8 @@ parse_json(Json) ->
     rpc:call(ct:get_config(ejabberd_node), mochijson2, decode, [Json]).
 
 start_lhttpc() ->
-    application:start(crypto),
-    application:start(public_key),
-    application:start(ssl),
-    application:start(lhttpc).
-
+    [ok,ok,ok,ok,ok] = lists:map(fun application:start/1,
+                                 [asn1,crypto,public_key,ssl,lhttpc]).
 stop_lhttpc() ->
-    application:stop(lhttpc),
-    application:stop(ssl),
-    application:stop(public_key),
-    application:stop(crypto).
+    [ok,ok,ok,ok,ok] = lists:map(fun application:stop/1,
+                                 [lhttpc,ssl,public_key,crypto,asn1]).


### PR DESCRIPTION
Escalus >= 2.4.1 provides the low-level function `escalus_bosh:mark_as_terminated/1`, which lets the programmer mark a client connection as not eligible for closing.
This is used in the `disconnect_inactive` test to silence 'session not found!' warnings on the server, triggered by `escalus_cleaner` trying to close the session.

OTP 17 is included in `rebar.config`

`metrics_helper` makes sure that all the applications it depends on are launched before starting `lhttpc`.
