### PR TITLE
Tolerate running applications when initialising metrics tests

### DIFF
--- a/tests/metrics_helper.erl
+++ b/tests/metrics_helper.erl
@@ -79,8 +79,19 @@ parse_json(Json) ->
     rpc:call(ct:get_config(ejabberd_node), mochijson2, decode, [Json]).
 
 start_lhttpc() ->
-    [ok,ok,ok,ok,ok] = lists:map(fun application:start/1,
-                                 [asn1,crypto,public_key,ssl,lhttpc]).
+    %% In R16B01 and above, we could use application:ensure_started/1
+    %% instead.
+    lists:foreach(
+      fun(App) ->
+	      case application:start(App) of
+		  ok ->
+		      ok;
+		  {error, {already_started, App}} ->
+		      ok;
+		  {error, E} ->
+		      error({cannot_start, E}, [App])
+	      end
+      end, [asn1,crypto,public_key,ssl,lhttpc]).
 stop_lhttpc() ->
     [ok,ok,ok,ok,ok] = lists:map(fun application:stop/1,
                                  [lhttpc,ssl,public_key,crypto,asn1]).


### PR DESCRIPTION
The entire metrics_c2s_SUITE used to be skipped, since
metrics_helper:start_lhttpc attempts to start five applications, exiting
with a badmatch if any of them are already running, which crypto,
public_key and ssl are.  This patch makes it accept 'already_started'
results from application:start.

Once we drop support for anything older than R16B01, we could use
application:ensure_started/1 here instead.
