### PR TITLE
bosh and WS fixes

### DIFF
--- a/tests/bosh_SUITE.erl
+++ b/tests/bosh_SUITE.erl
@@ -29,16 +29,17 @@
 -define(INVALID_RID_OFFSET, 999).
 
 all() ->
-    [%{group, essential}
-     {group, chat}
-     %{group, time},
-     %{group, acks}
+    [{group, essential},
+     {group, chat},
+     {group, time},
+     {group, acks}
     ].
 
 groups() ->
     [{essential, [{repeat,10}], [create_and_terminate_session]},
      {chat, [shuffle, {repeat,10}], [interleave_requests,
                                      simple_chat,
+                                     cdata_escape_chat,
                                      cant_send_invalid_rid,
                                      multiple_stanzas,
                                      namespace,
@@ -211,6 +212,22 @@ simple_chat(Config) ->
                        escalus_client:wait_for_stanza(Carol))
 
         end).
+
+cdata_escape_chat(Config) ->
+    escalus:story(Config, [{carol, 1}, {geralt, 1}], fun(Carol, Geralt) ->
+
+        Message = <<"Hi! & < > ">>,
+        Stanza = escalus_stanza:chat_to(Carol, Message),
+        escalus_client:send(Carol, Stanza),
+        escalus:assert(is_chat_message, [Message],
+            escalus_client:wait_for_stanza(Carol)),
+
+        escalus_client:send(Geralt,
+            escalus_stanza:chat_to(Carol, Message)),
+        escalus:assert(is_chat_message, [Message],
+            escalus_client:wait_for_stanza(Carol))
+
+    end).
 
 cant_send_invalid_rid(Config) ->
     escalus:story(Config, [{carol, 1}], fun(Carol) ->

--- a/tests/websockets_SUITE.erl
+++ b/tests/websockets_SUITE.erl
@@ -30,7 +30,7 @@ all() ->
     [{group, ws_chat}].
 
 groups() ->
-    [{ws_chat, [sequence], [chat_msg]}].
+    [{ws_chat, [sequence], [chat_msg, escape_chat_msg]}].
 
 suite() ->
     escalus:suite().
@@ -74,6 +74,22 @@ chat_msg(Config) ->
         escalus_assert:is_chat_message(<<"Hey!">>, escalus_client:wait_for_stanza(Oldie))
 
         end).
+
+escape_chat_msg(Config) ->
+    escalus:story(Config, [{alice, 1}, {geralt, 1}, {oldie, 1}], fun(Alice, Geralt, Oldie) ->
+        Message1 = <<"Hi! & < >">>,
+        escalus_client:send(Alice, escalus_stanza:chat_to(Geralt, Message1)),
+        escalus:assert(is_chat_message, [Message1], escalus_client:wait_for_stanza(Geralt)),
+
+        Message2 = <<"Hello! & < >">>,
+        escalus_client:send(Geralt, escalus_stanza:chat_to(Alice, Message2)),
+        escalus:assert(is_chat_message, [Message2], escalus_client:wait_for_stanza(Alice)),
+
+        Message3= <<"Hey! & < >">>,
+        escalus_client:send(Geralt, escalus_stanza:chat_to(Oldie, Message3)),
+        escalus_assert:is_chat_message(Message3, escalus_client:wait_for_stanza(Oldie))
+
+    end).
 
 %%--------------------------------------------------------------------
 %% Helpers


### PR DESCRIPTION
This are tests for esl/MongooseIM#216
- in BOSH every statnza should be in namespace "jabber:client"
- some special characters like `&`, `<` and `>` has to be properly escaped
