### PR TITLE
Add ready to use test spec templates in default.spec

### DIFF
--- a/default.spec
+++ b/default.spec
@@ -1,3 +1,13 @@
+%% Spec examples:
+%%
+%%   {suites, "tests", amp_SUITE}.
+%%   {groups, "tests", amp_SUITE, [discovery]}.
+%%   {groups, "tests", amp_SUITE, [discovery], {cases, [stream_feature_test]}}.
+%%   {cases, "tests", amp_SUITE, [stream_feature_test]}.
+%%
+%% For more info see:
+%% http://www.erlang.org/doc/apps/common_test/run_test_chapter.html#test_specifications
+
 {suites, "tests", adhoc_SUITE}.
 {suites, "tests", amp_SUITE}.
 {suites, "tests", last_SUITE}.


### PR DESCRIPTION
I keep forgetting the format of these specs again and again, and I might not be the only one with this problem...
