### PR TITLE
fix block_jid_presence_out

### DIFF
--- a/tests/privacy_SUITE.erl
+++ b/tests/privacy_SUITE.erl
@@ -467,6 +467,11 @@ block_jid_presence_out(Config) ->
         %% Bob should NOT receive presence in
         escalus_client:send(Alice,
             escalus_stanza:presence_direct(bob, <<"available">>)),
+
+        %% Alice gets an error back from mod_privacy
+        Presence = escalus_client:wait_for_stanza(Alice),
+        escalus:assert(is_presence_with_type, [<<"error">>], Presence),
+
         timer:sleep(?SLEEP_TIME),
         escalus_assert:has_no_stanzas(Bob)
 


### PR DESCRIPTION
If shapers are set to higher values there will be an error for this (and many others in sm_SUITE, but that's another thing, this only fixes the bad one in privacy_SUITE). 
