### PR TITLE
Use & document {escalus_user_db, {module, Mod}} option

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {require_otp_vsn, "R?1[4567]"}.
 
 {deps, [
-        {escalus, "2\.6.\.*", {git, "git://github.com/esl/escalus.git", {tag, "85cbe4b48e18f77a5383a8e45712eddd958ae32f"}}},
+        {escalus, "2\.6.\.*", {git, "git://github.com/esl/escalus.git", {branch, "escalus-users"}}},
         {exml, "2\.1\..*", {git, "git://github.com/esl/exml.git", {tag, "2.1.5"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},
         {katt, ".*", {git, "git://github.com/for-GET/katt.git", "e14ac2c8dfde73dc7b4d1526b9fa702ccf95a8a8"}}

--- a/test.config
+++ b/test.config
@@ -13,7 +13,13 @@
 {ejabberd_metrics_rest_port, 5280}.
 {ejabberd_string_format, bin}.
 
-{escalus_user_db, xmpp}. %% escalus:create_users will perform in-band registration
+%% Use XMPP in-band registration for creating/deleting test users
+{escalus_user_db, xmpp}.
+
+%% Use modules that implement the escalus_user_db behaviour:
+%% {escalus_user_db, {module, escalus_ejabberd}}. % RPC-based registration
+%% {escalus_user_db, {module, YourModule}}.
+%% {escalus_user_db, {module, YourModule, ListOfOptions}}.
 
 {escalus_users, [
     {alice, [

--- a/tests/bosh_SUITE.erl
+++ b/tests/bosh_SUITE.erl
@@ -74,7 +74,7 @@ acks_test_cases() ->
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    escalus:init_per_suite([{escalus_user_db, ejabberd} | Config]).
+    escalus:init_per_suite([{escalus_user_db, {module, escalus_ejabberd}} | Config]).
 
 end_per_suite(Config) ->
     escalus:end_per_suite(Config).


### PR DESCRIPTION
The `escalus_user_db` behavior has been streamlined to take one of the three forms:
`{esaclus_user_db, xmpp}`  - for in-band registration
`{escalus_user_db, {module, M}}`  == `{escalus_user_db, {module, M, []}}`
`{escalus_user_db, {module, M, Args}}` - use a module M, that implements `escalus_user_db`, passing Args as the argument to `start/1`
