### PR TITLE
connect: Check features when STARTTLS is required.

### DIFF
--- a/tests/connect_SUITE.erl
+++ b/tests/connect_SUITE.erl
@@ -56,7 +56,8 @@ groups() ->
 test_cases() ->
     generate_tls_vsn_tests() ++
     [should_fail_with_sslv3,
-     should_fail_to_authenticate_without_starttls].
+     should_fail_to_authenticate_without_starttls,
+     should_not_send_other_features_with_starttls_required].
 
 suite() ->
     escalus:suite().
@@ -188,6 +189,15 @@ should_fail_to_authenticate_without_starttls(Config) ->
                                              <<"Use of STARTTLS required">>],
                            AuthReply)
     end.
+
+should_not_send_other_features_with_starttls_required(Config) ->
+    UserSpec = escalus_users:get_userspec(Config, ?SECURE_USER),
+    {ok, Conn, _, _} = escalus_connection:start(UserSpec, [start_stream]),
+    Features = escalus_connection:get_stanza(Conn, wait_for_features),
+    #xmlel{name = <<"features">>, children = FeatureChildren} = Features,
+    ?assertMatch([#xmlel{name = starttls,
+                         children = [#xmlel{name = required}]}],
+                 FeatureChildren).
 
 %%--------------------------------------------------------------------
 %% Internal functions


### PR DESCRIPTION
According to RFC6120 section 5.3.1, the server SHOULD NOT advertise any features before the client has done a successful `<starttls/>`:

http://xmpp.org/rfcs/rfc6120.html#tls-rules-mtn

Right now, MongooseIM returns the same feature list before and after the `<starttls/>`, which causes troubles in some clients like Gajim on Windows.

While I haven't been able to fully debug why only the Windows version is trying to authenticate without STARTTLS, I believe we really _should_ do what the RFC recommends and that's what the check is for.

Note that I haven't yet run the test suite with this (need to fix up the test suite for my deployment first) and we actually need to fix the implementation itself as well, pull request coming soon.