### PR TITLE
Fixed katt dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
         {exml, "2\.1\..*", {git, "git://github.com/esl/exml.git", {tag, "2.1.5"}}},
         {usec, ".*", {git, "git://github.com/esl/usec.git", {branch, "master"}}},
         {mustache, ".*", {git, "git://github.com/mojombo/mustache.erl.git", {branch, "master"}}},
-        {katt, ".*", {git, "git://github.com/for-GET/katt.git", "e14ac2c8dfde73dc7b4d1526b9fa702ccf95a8a8"}},
+        {katt, ".*", {git, "git://github.com/for-GET/katt.git", {tag, "1.4.0"}}},
         {proper, ".*", {git, "https://github.com/manopapad/proper.git", "20e62bc32f9bd43fe2ff52944a4ef99eb71d1399"}}
 ]}.
 

--- a/tests/connect_SUITE.erl
+++ b/tests/connect_SUITE.erl
@@ -56,7 +56,8 @@ groups() ->
 test_cases() ->
     generate_tls_vsn_tests() ++
     [should_fail_with_sslv3,
-     should_fail_to_authenticate_without_starttls].
+     should_fail_to_authenticate_without_starttls,
+     should_not_send_other_features_with_starttls_required].
 
 suite() ->
     escalus:suite().
@@ -188,6 +189,17 @@ should_fail_to_authenticate_without_starttls(Config) ->
                                              <<"Use of STARTTLS required">>],
                            AuthReply)
     end.
+
+should_not_send_other_features_with_starttls_required(Config) ->
+    UserSpec = escalus_users:get_userspec(Config, ?SECURE_USER),
+    {ok, Conn, _, _} = escalus_connection:start(UserSpec, [start_stream]),
+    Features = case escalus_connection:get_stanza(Conn, wait_for_features) of
+        #xmlel{name = <<"stream:features">>, children = Children} -> Children;
+        #xmlel{name = <<"features">>, children = Children} -> Children
+    end,
+    ?assertMatch([#xmlel{name = <<"starttls">>,
+                         children = [#xmlel{name = <<"required">>}]}],
+                 Features).
 
 %%--------------------------------------------------------------------
 %% Internal functions


### PR DESCRIPTION
Previous configuration with 'rebar get-deps' command was unsuccessful. It was not compatibile with lhttpc.
